### PR TITLE
LUT-32906 : Fix time input type and update indexer

### DIFF
--- a/src/java/fr/paris/lutece/plugins/appointment/modules/management/service/indexer/LuteceAppointmentSearchIndexer.java
+++ b/src/java/fr/paris/lutece/plugins/appointment/modules/management/service/indexer/LuteceAppointmentSearchIndexer.java
@@ -155,12 +155,11 @@ public class LuteceAppointmentSearchIndexer implements IAppointmentSearchIndexer
     public void indexDocuments( ) throws IOException, InterruptedException, SiteMessageException
     {
         List<Integer> listAppointmentId = AppointmentHome.selectAllAppointmentId( );
-
-        deleteIndex( );
         _bIndexToLunch.set( true );
 
         if ( _bIndexIsRunning.compareAndSet( false, true ) )
         {
+            deleteIndex( );
             new Thread( new IndexerRunnable( listAppointmentId ) ).start( );
         }
     }

--- a/webapp/WEB-INF/templates/admin/plugins/appointment/modules/management/multiview_appointments.html
+++ b/webapp/WEB-INF/templates/admin/plugins/appointment/modules/management/multiview_appointments.html
@@ -66,7 +66,7 @@
 							<@columns md=3>
 								<@formGroup labelFor='startingTimeOfSearch' labelKey='#i18n{appointment.labelTo}' rows=2>
 									<@inputGroup>
-										<@input type='time' name='startingTimeOfSearch' id='startingTimeOfSearch' value='${filter.startingTimeOfSearch!\'\'}' />
+										<@input type='html5time' name='startingTimeOfSearch' id='startingTimeOfSearch' value='${filter.startingTimeOfSearch!\'\'}' />
 										<@inputGroupItem type='text'>
 											<@icon style='clock-o' />
 										</@inputGroupItem>
@@ -86,7 +86,7 @@
 							<@columns md=3>
 								<@formGroup labelFor='endingTimeOfSearch' labelKey='#i18n{appointment.labelTo}' rows=2>
 									<@inputGroup>
-										<@input type='time' name='endingTimeOfSearch' id='endingTimeOfSearch' value='${filter.endingTimeOfSearch!\'\'}' />
+										<@input type='html5time' name='endingTimeOfSearch' id='endingTimeOfSearch' value='${filter.endingTimeOfSearch!\'\'}' />
 										<@inputGroupItem type='text'>
 											<@icon style='clock-o' />
 										</@inputGroupItem>


### PR DESCRIPTION
- Add type html5time to be compatible with input 'HH:mm'
- Fix issue when we lost some datas during indexation. It happened when an indexation is launched during a another one is in progress. The delete index is not under some condition to check if it secure to delete the current indexation. So we put it in the condition bIndexIsRunning.